### PR TITLE
do also symbols

### DIFF
--- a/docs/src/get_started.md
+++ b/docs/src/get_started.md
@@ -73,7 +73,7 @@ function (hm::YourHybridModelName)(dataset_keyed, ps, st)
   # output from Neural network application 
   β, st = LuxCore.apply(hm.NN, p, ps.ps, st.st) # [!code highlight]
 
-  # equation! this is where were you should focus, your model!
+  # equation! this is where you should focus, your model!
   ŷ = β .* ps.α .^(0.1f0 * (x .- 15.0f0)) # [!code warning]
 
   return (; ŷ), (; β, st) # always output predictions and states as two tuples

--- a/projects/RbQ10/Q10.jl
+++ b/projects/RbQ10/Q10.jl
@@ -49,16 +49,16 @@ output_file = joinpath(@__DIR__, "output_tmp/trained_model.jld2")
 
 all_groups = get_all_groups(output_file)
 
-predictions = load_group(output_file, "predictions")
+predictions = load_group(output_file, :predictions)
 
-physical_params, _ = load_group(output_file, "physical_params")
+physical_params, _ = load_group(output_file, :physical_params)
 
 series(WrappedTuples(physical_params); axis=(; xlabel = "epoch", ylabel=""))
 
-training_loss, _ = load_group(output_file, "training_loss")
+training_loss, _ = load_group(output_file, :training_loss)
 series(WrappedTuples(WrappedTuples(training_loss).mse); axis=(; xlabel = "epoch", ylabel="training loss", xscale=log10, yscale=log10))
 
-validation_loss, _ = load_group(output_file, "validation_loss")
+validation_loss, _ = load_group(output_file, :validation_loss)
 series(WrappedTuples(WrappedTuples(validation_loss).mse); axis=(; xlabel = "epoch", ylabel="validation loss", xscale=log10, yscale=log10))
 
 

--- a/src/utils/io.jl
+++ b/src/utils/io.jl
@@ -9,7 +9,7 @@ function save_ps_st(file_name, hm, ps, st, save_ps)
     end
 
     jldopen(file_name, "w") do file
-        file["HybridModel:$hm_name/epoch_0"] = (ps, st)
+        file["HybridModel_$hm_name/epoch_0"] = (ps, st)
         if !isempty(save_ps)
             file["physical_params/epoch_0"] = tmp_e
         end
@@ -25,7 +25,7 @@ function save_ps_st!(file_name, hm, ps, st, save_ps, epoch)
     end
 
     jldopen(file_name, "a+") do file
-        file["HybridModel:$hm_name/epoch_$epoch"] = (ps, st)
+        file["HybridModel_$hm_name/epoch_$epoch"] = (ps, st)
         if !isempty(save_ps)
             file["physical_params/epoch_$epoch"] = tmp_e
         end
@@ -58,6 +58,7 @@ function to_named_tuple(ka, target_names)
 end
 
 function load_group(file_name, group)
+    group = string(group)
     group_tmp = JLD2.load(file_name, group)
     group_keys = collect(keys(group_tmp))
     if occursin("epoch", first(group_keys))
@@ -70,14 +71,14 @@ function load_group(file_name, group)
 end
 
 function get_all_groups(filename)
-    groups = String[]
+    groups = Symbol[]
     JLD2.jldopen(filename, "r") do file
         function recurse_groups(g, path="")
             for k in keys(g)
                 obj = g[k]
                 newpath = joinpath(path, k)
                 if obj isa JLD2.Group
-                    push!(groups, newpath)
+                    push!(groups, Symbol(newpath))
                     recurse_groups(obj, newpath)
                 end
             end


### PR DESCRIPTION
ideally, `out -> result` should only output an entity with the groups and load them afterwards with a special function.