### PR TITLE
fix prepare data, and add k-folds support

### DIFF
--- a/projects/RbQ10/Q10.jl
+++ b/projects/RbQ10/Q10.jl
@@ -1,16 +1,16 @@
 # CC BY-SA 4.0
 # activate the project's environment and instantiate dependencies
 using Pkg
-Pkg.activate("projects/RbQ10")
-Pkg.develop(path=pwd())
-Pkg.instantiate()
+# Pkg.activate("projects/RbQ10")
+# Pkg.develop(path=pwd())
+# Pkg.instantiate()
 
 # start using the package
 using EasyHybrid
 
 # for Plotting
 using GLMakie
-using AlgebraOfGraphics
+# using AlgebraOfGraphics
 
 # Local Path (MPI-BGC server):
 #   /Net/Groups/BGI/scratch/bahrens/DataHeinemeyerRh/RESP_07_08_09_10_filled.csv
@@ -46,7 +46,12 @@ ls_logs = EasyHybrid.lossfn(RbQ10, ds_p_f, (ds_t, ds_t_nan), ps, st, LoggingLoss
 
 # ? play with :Temp as predictors in NN, temperature sensitivity!
 # TODO: variance effect due to LSTM vs NN
-out = train(RbQ10, (ds_p_f, ds_t), (:Q10, ); nepochs=200, batchsize=512, opt=Adam(0.01));
+out = train(RbQ10, (ds_p_f, ds_t), (:Q10, ); nepochs=50, batchsize=512, opt=Adam(0.01));
+
+sdata = EasyHybrid.split_data((ds_p_f, ds_t), RbQ10)
+
+# in already split data, useful for k-fold cross validation!
+out = train(RbQ10, sdata, (:Q10, ); nepochs=200, batchsize=512, opt=Adam(0.01));
 
 output_file = joinpath(@__DIR__, "output_tmp/trained_model.jld2")
 # o = jldopen(output_file, "r")

--- a/src/train.jl
+++ b/src/train.jl
@@ -52,13 +52,19 @@ function split_data(data::Union{DataFrame, KeyedArray}, hybridModel; split_by_id
     return (x_train, y_train), (x_val, y_val)
 end
 
-function split_data(data::AbstractDimArray, hybridModel;  split_by_id=nothing, shuffleobs=false, split_data_at=0.8)
+function split_data(data::AbstractDimArray, hybridModel; split_by_id=nothing, shuffleobs=false, split_data_at=0.8)
     data_ = prepare_data(hybridModel, data)
     (x_train, y_train), (x_val, y_val) = splitobs(data_; at=split_data_at, shuffle=shuffleobs)
     return (x_train, y_train), (x_val, y_val)
 end
 
-function split_data(data::Tuple, hybridModel; kwargs...)
+function split_data(data::Tuple, hybridModel; split_by_id=nothing, shuffleobs=false, split_data_at=0.8)
+    data_ = prepare_data(hybridModel, data)
+    (x_train, y_train), (x_val, y_val) = splitobs(data_; at=split_data_at, shuffle=shuffleobs)
+    return (x_train, y_train), (x_val, y_val)
+end
+
+function split_data(data::Tuple{Tuple, Tuple}, hybridModel; kwargs...)
     return data
 end
 


### PR DESCRIPTION
@BernhardAhrens 

- [x] this brings back the old behaviour from prepare_data (now in split_data)
- [x] Adds a dispatch on `split_data` where if you pass a `data::Tuple{Tuple, Tuple}` we assume that the user has already preprocessed the data into `(x_train, y_train) and (x_val, y_val)`, allowing for `k-fold` cross validation scenarios. 

tested on the Q10 example 😄 .