### PR TITLE
for list comprehension of train_history

### DIFF
--- a/src/utils/wrap_tuples.jl
+++ b/src/utils/wrap_tuples.jl
@@ -10,7 +10,7 @@ struct WrappedTuples{T <: AbstractVector{<:NamedTuple}} <: AbstractVector{NamedT
 end
 
 # Required methods for AbstractVector
-Base.size(w::WrappedTuples) = (length(w.data), length(first(w.data)))
+Base.size(w::WrappedTuples) = (length(w.data),)
 Base.getindex(w::WrappedTuples, i::Int) = w.data[i]
 Base.getindex(w::WrappedTuples, r::AbstractRange) = WrappedTuples(w.data[r])
 Base.IndexStyle(::Type{<:WrappedTuples}) = IndexLinear()


### PR DESCRIPTION
Needed to make this ```[row.nse.SOC for row in o_SOC.val_history]``` work

Otherwise I would need to do this 
```[row.nse.SOC for row in o_SOC.val_history.data]```

The .data is not very intuitive. Does not affect train (I tested), not sure if this would affect anything else @lazarusA 